### PR TITLE
Epic Games – Filter Free Games & Modernize Integration

### DIFF
--- a/custom_components/epic_games/__init__.py
+++ b/custom_components/epic_games/__init__.py
@@ -6,9 +6,15 @@ from homeassistant import config_entries, core
 from homeassistant.const import Platform
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
+from urllib3.util.retry import Retry
 
-from .const import BASE_URL, DOMAIN, CONF_LOCALE, CONF_COUNTRY, CONF_ALLOW_COUNTRIES
+from .const import (
+    BASE_URL,
+    DOMAIN,
+    CONF_LOCALE,
+    CONF_COUNTRY,
+    CONF_ALLOW_COUNTRIES,
+)
 
 PLATFORMS = [Platform.SENSOR]
 
@@ -17,22 +23,25 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: core.HomeAssistant, entry: config_entries.ConfigEntry
-):
-    if await get_games(
+) -> bool:
+    """Set up Epic Games from a config entry."""
+
+    data = await get_games(
         hass=hass,
         locale=entry.data.get(CONF_LOCALE),
         country=entry.data.get(CONF_COUNTRY),
         allow_countries=entry.data.get(CONF_ALLOW_COUNTRIES),
-    ):
-        hass.data.setdefault(DOMAIN, {})
-        hass.data[DOMAIN][entry.entry_id] = entry.data
+    )
 
-        for platform in PLATFORMS:
-            hass.async_create_task(
-                hass.config_entries.async_forward_entry_setup(entry, platform)
-            )
-    else:
-        raise ConfigEntryAuthFailed("Invalid credentials")
+    if not data:
+        raise ConfigEntryAuthFailed("Invalid credentials or API error")
+
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = entry.data
+
+    # API NUEVA (Home Assistant moderno)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
     return True
 
 
@@ -41,14 +50,18 @@ async def async_unload_entry(
 ) -> bool:
     """Unload a config entry."""
 
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok and DOMAIN in hass.data:
+        hass.data[DOMAIN].pop(entry.entry_id, None)
+
     return unload_ok
 
 
 async def async_migrate_entry(
     hass: core.HomeAssistant, config_entry: config_entries.ConfigEntry
-):
+) -> bool:
+    """Migrate old config entries."""
+
     hass.config_entries.async_update_entry(
         config_entry,
         data={
@@ -64,22 +77,39 @@ async def async_migrate_entry(
 async def get_games(
     hass, locale: str, country: str, allow_countries: str
 ) -> Union[dict, Optional[None]]:
+    """Fetch free games from Epic Games API."""
+
     def get():
-        url = f"{BASE_URL}/freeGamesPromotions?locale={locale}&country={country}&allowCountries={allow_countries}"
+        url = (
+            f"{BASE_URL}/freeGamesPromotions"
+            f"?locale={locale}&country={country}&allowCountries={allow_countries}"
+        )
+
         retry_strategy = Retry(
             total=3,
             status_forcelist=[400, 401, 500, 502, 503, 504],
-            method_whitelist=["GET"],
+            allowed_methods=["GET"],
         )
-        adapter = HTTPAdapter(max_retries=retry_strategy)
-        http = requests.Session()
-        http.mount("https://", adapter)
 
-        return http.get(url, headers={"User-Agent": "Mozilla/5.0"})
+        adapter = HTTPAdapter(max_retries=retry_strategy)
+        session = requests.Session()
+        session.mount("https://", adapter)
+
+        return session.get(
+            url,
+            headers={"User-Agent": "Mozilla/5.0"},
+            timeout=20,
+        )
 
     response = await hass.async_add_executor_job(get)
-    _LOGGER.debug("API Response movies: %s", response.json())
+    _LOGGER.debug("Epic Games API response: %s", response.text)
 
     if response.ok:
         return response.json()
+
+    _LOGGER.error(
+        "Epic Games API error %s: %s",
+        response.status_code,
+        response.text,
+    )
     return None

--- a/custom_components/epic_games/sensor.py
+++ b/custom_components/epic_games/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import Entity
 from homeassistant.util.dt import utc_from_timestamp
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
+from urllib3.util.retry import Retry
 
 from .const import (
     BASE_URL,
@@ -152,7 +152,7 @@ class EpicGamesSensor(Entity):
         retry_strategy = Retry(
             total=3,
             status_forcelist=[400, 401, 500, 502, 503, 504],
-            method_whitelist=["GET"],
+            allowed_methods=["GET"],
         )
         adapter = HTTPAdapter(max_retries=retry_strategy)
         http = requests.Session()
@@ -187,6 +187,9 @@ class EpicGamesSensor(Entity):
                         airdate=game["viewableDate"].split("T")[0],
                     )
                     for game in parsed_games
+		    if game.get("promotions") and game["promotions"].get("promotionalOffers")
+		    and game.get("price",{}).get("totalPrice", {}).get("originalPrice", 0)
+		    == game.get("price", {}).get("totalPrice", {}).get("discount", -1)
                 ]
             )
 

--- a/custom_components/epic_games/sensor.py
+++ b/custom_components/epic_games/sensor.py
@@ -187,6 +187,9 @@ class EpicGamesSensor(Entity):
                         airdate=game["viewableDate"].split("T")[0],
                     )
                     for game in parsed_games
+		    if game.get("promotions") and game["promotions"].get("promotionalOffers")
+		    and game.get("price",{}).get("totalPrice", {}).get("originalPrice", 0)
+		    == game.get("price", {}).get("totalPrice", {}).get("discount", -1)
                 ]
             )
 


### PR DESCRIPTION
## Description

This PR combines **functional improvements** and **compatibility fixes** for the Epic Games integration in Home Assistant.

---

## Functional change

The Epic Games sensor has been updated to **only return games that are currently 100% free**.

Previously, the sensor included **all promotional games**, even those with partial discounts.
With this update, results are filtered using the `promotions` field and by comparing `originalPrice` with `discount`, ensuring that **only completely free games** are displayed.

---

## Compatibility and maintenance fixes

This PR also updates the integration to be compatible with **modern Home Assistant and Python versions**:

- Replaced deprecated `method_whitelist` with `allowed_methods` in `urllib3.Retry`
- Updated `Retry` imports to use `urllib3.util.retry` instead of deprecated `requests.packages`
- Migrated Home Assistant API usage from `async_forward_entry_setup` to `async_forward_entry_setups`
- Improved async handling to align with current Home Assistant standards

These changes prevent runtime errors on Home Assistant versions running **Python 3.12+ / 3.13**.

---

## Example card

To display Epic Games information in Home Assistant, you can use the following example card.
Make sure to install the [upcoming-media-card](https://github.com/NemesisRE/upcoming-media-card).

```yaml
type: custom:upcoming-media-card
entity: sensor.epic_games
title: Epic Games
max: 10
image_style: fanart
date: ddmm
line1_text: "Metacritic: $rating"
```
---

## Epic Games – Free Games (as of 2025-08-23)

This screenshot shows the current free games available on the Epic Games Store.

<img width="1425" height="738" alt="Epic Games free games" src="https://github.com/user-attachments/assets/ddff266f-99a0-4db9-88c4-a5c1dc3ddf51" />
---

## Current behavior (original code)

The sensor listed all Epic Games promotions, including titles that were not fully free.
Even when reducing max from 10 to 2, partially discounted games could still appear.

<img width="676" height="1604" alt="Original behavior" src="https://github.com/user-attachments/assets/206575a0-a3fc-43eb-a492-b61b30b40b18" />
---

## New behavior (with this PR)

With this update, the sensor now lists only games with a 100% discount.
Even when setting max: 10, results are limited exclusively to truly free games.

<img width="670" height="506" alt="New behavior" src="https://github.com/user-attachments/assets/bf2b77ce-ce74-49b2-ae4e-96f1c86f1d84" /> ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling and logging for Epic Games API responses, providing clearer error messages when issues occur.

* **Chores**
  * Optimized setup and configuration flow for better reliability.
  * Updated filtering logic for games list to display only promotions with matching price information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->